### PR TITLE
Fix invalid track texture tiles in WOXL/WO2097

### DIFF
--- a/wipeout.js
+++ b/wipeout.js
@@ -38,6 +38,9 @@ Wipeout.prototype.clear = function() {
 	this.sceneMaterial = {};
 	this.trackMaterial = null;
 	this.weaponTileMaterial = null;
+	
+	this.startTime = Date.now();
+	this.ticks = 0;
 };
 
 Wipeout.prototype.resize = function() {
@@ -64,38 +67,16 @@ Wipeout.prototype.animate = function() {
 
 	// Camera is in fly mode and we have a spline to follow?
 	if( this.activeCameraMode === 'fly' && this.cameraSpline ) {
-		var damping = 0.90;
+	
+		var elapsedTime = time - this.startTime;
+		var elapsedTicks = elapsedTime / 1000 * 60;
 
-		var loopTime = this.cameraSpline.points.length * 100;
-
-		// Camera position along the spline
-		var tmod = ( time % loopTime ) / loopTime;
-		var cameraPos = this.cameraSpline.getPointAt( tmod ).clone();
-		this.splineCamera.position.multiplyScalar(damping)
-			.add(cameraPos.clone().add({x:0, y:600, z:0}).multiplyScalar(1-damping));
-
-		// Camera lookAt along the spline
-		var tmodLookAt = ( (time+800) % loopTime ) / loopTime;
-		var lookAtPos = this.cameraSpline.getPointAt( tmodLookAt ).clone();
-		this.splineCamera.currentLookAt = this.splineCamera.currentLookAt.multiplyScalar(damping)
-			.add(lookAtPos.clone().multiplyScalar(1-damping));
-		this.splineCamera.lookAt(this.splineCamera.currentLookAt);
-
-		// Roll into corners - there's probably an easier way to do this. This 
-		// takes the angle between the current camera position and the current
-		// lookAt, applies some damping and rolls the camera along its view vector
-		var cn = cameraPos.sub(this.splineCamera.position);
-		var tn = lookAtPos.sub(this.splineCamera.currentLookAt);
-		var roll = (Math.atan2(cn.z, cn.x) - Math.atan2(tn.z, tn.x));
-		roll += (roll > Math.PI)
-			? -Math.PI*2 
-			: (roll < -Math.PI) ? Math.PI * 2 : 0;
-
-		this.splineCamera.roll = this.splineCamera.roll * 0.95 + (roll)*0.1;
-		this.splineCamera.up = (new THREE.Vector3(0,1,0)).applyAxisAngle(
-			this.splineCamera.position.clone().sub(this.splineCamera.currentLookAt).normalize(),
-			this.splineCamera.roll * 0.25
-		);
+		//fixed time step loop (60hz)
+		while(this.ticks < elapsedTicks) {
+		
+			this.updateSplineCamera();
+			this.ticks++;
+		}
 		
 		this.rotateSpritesToCamera(this.splineCamera);
 		this.renderer.render(this.scene, this.splineCamera);
@@ -108,6 +89,43 @@ Wipeout.prototype.animate = function() {
 		this.renderer.render( this.scene, this.camera );
 	}
 };
+
+Wipeout.prototype.updateSplineCamera = function() {
+	var damping = 0.90;
+	var time = this.ticks * 1000 / 60;
+
+	var loopTime = this.cameraSpline.points.length * 100;
+
+	// Camera position along the spline
+	var tmod = ( time % loopTime ) / loopTime;
+	var cameraPos = this.cameraSpline.getPointAt( tmod ).clone();
+	this.splineCamera.position.multiplyScalar(damping)
+		.add(cameraPos.clone().add({x:0, y:600, z:0}).multiplyScalar(1-damping));
+
+	// Camera lookAt along the spline
+	var tmodLookAt = ( (time+800) % loopTime ) / loopTime;
+	var lookAtPos = this.cameraSpline.getPointAt( tmodLookAt ).clone();
+	this.splineCamera.currentLookAt = this.splineCamera.currentLookAt.multiplyScalar(damping)
+		.add(lookAtPos.clone().multiplyScalar(1-damping));
+	this.splineCamera.lookAt(this.splineCamera.currentLookAt);
+
+	// Roll into corners - there's probably an easier way to do this. This 
+	// takes the angle between the current camera position and the current
+	// lookAt, applies some damping and rolls the camera along its view vector
+	var cn = cameraPos.sub(this.splineCamera.position);
+	var tn = lookAtPos.sub(this.splineCamera.currentLookAt);
+	var roll = (Math.atan2(cn.z, cn.x) - Math.atan2(tn.z, tn.x));
+	roll += (roll > Math.PI)
+		? -Math.PI*2 
+		: (roll < -Math.PI) ? Math.PI * 2 : 0;
+
+	this.splineCamera.roll = this.splineCamera.roll * 0.95 + (roll)*0.1;
+	this.splineCamera.up = (new THREE.Vector3(0,1,0)).applyAxisAngle(
+		this.splineCamera.position.clone().sub(this.splineCamera.currentLookAt).normalize(),
+		this.splineCamera.roll * 0.25
+	);
+}
+
 
 Wipeout.prototype.rotateSpritesToCamera = function(camera) {
 	for( var i = 0; i < this.sprites.length; i++ ) {


### PR DESCRIPTION
This fix the issue discussed there : https://github.com/phoboslab/wipeout/issues/6

These track tiles indexes are actually located in TRACK.TEX file (this is applicable for all WOXL/W2097 tracks, except buggy/hidden TRACK04 which does not have such a file in its folder).

It seems that WOXL/WO2097 dev team decided during development to move track texture indexes into a separate TEX file, instead of just using TRF file (as it is for WO1) . 
Old tile indexes in TRF files were keep intact and that explain why it still works to use TRF files for some tracks. Were "Gare d'europa" and "Spliskinanke" the latest tracks to be created in the game ? 

Since TRACK.TEX does not always exists I had to modify a little bit loadBinary() to handle this. The other way, i think, is to hardcode as data (in the JS file) if the file should be loaded or not.

Additionally : 
- I have updated TRF structure info (found some stuff while trying to figure out where those track tile indexes were defined)
- Small changes to weapon track tile settings to closely match original game. The first initial implementation 33a3e63  using THREE.Color.setHSL() just worked, but was not faithful to original game.
